### PR TITLE
Use xvfb-run to perform unit tests

### DIFF
--- a/master.cfg
+++ b/master.cfg
@@ -83,7 +83,7 @@ factory.addStep(Compile(
     name='unit tests',
     description='testing',
     descriptionDone='test',
-    command=['./unittest.sh'],
+    command=['xvfb-run ./unittest.sh'],
     logfiles=config['LOGFILES'],
     lazylogfiles=True,
 ))
@@ -140,7 +140,7 @@ hc_factory.addStep(Compile(
     name='unit tests',
     description='testing',
     descriptionDone='test',
-    command=['./unittest.sh'],
+    command=['xvfb-run ./unittest.sh'],
     env={'HEAPCHECK': 'normal',
          'PPROF_PATH': '/usr/bin/google-pprof'},
     logfiles=config['LOGFILES'],


### PR DESCRIPTION
Unit tests fail on my slave because they need access to a X server display.
This can be done with xvfb without interfering with the actual X server running on the slave.

If I manually  do 'xvfb-run ./unittest.sh' all the tests pass.
Unfortunately I haven't been able to figure out how to do it automatically on the slave side, so I'm proposing this PR to force the use of xvfb to all the slaves.

Any better solution is welcome :smiley: 
