### PR TITLE
Revert xvfb patch. Buildbot detection moved into unittest.sh script

### DIFF
--- a/master.cfg
+++ b/master.cfg
@@ -83,7 +83,7 @@ factory.addStep(Compile(
     name='unit tests',
     description='testing',
     descriptionDone='test',
-    command=['xvfb-run ./unittest.sh'],
+    command=['./unittest.sh'],
     logfiles=config['LOGFILES'],
     lazylogfiles=True,
 ))
@@ -140,7 +140,7 @@ hc_factory.addStep(Compile(
     name='unit tests',
     description='testing',
     descriptionDone='test',
-    command=['xvfb-run ./unittest.sh'],
+    command=['./unittest.sh'],
     env={'HEAPCHECK': 'normal',
          'PPROF_PATH': '/usr/bin/google-pprof'},
     logfiles=config['LOGFILES'],


### PR DESCRIPTION
Please revert my patch.
I just realized this is NOT OK on OSX (probably there is not even a port of xvfb)

Once this is merged, I will commit a patch on unittest.sh where I will detect the user (whoami == 'buildbot') and the OS to determine if I need to prefix the tests with 'xvfb-run'.

Thanks
